### PR TITLE
feat(commands): add reset-password command

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -50,6 +50,8 @@ pub enum RuntipiMainCommand {
     Update(UpdateCommand),
     /// Manage your apps
     App(AppCommand),
+    /// Reset your runtipi password
+    ResetPassword,
     /// Debug your runtipi instance
     Debug,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -50,7 +50,7 @@ pub enum RuntipiMainCommand {
     Update(UpdateCommand),
     /// Manage your apps
     App(AppCommand),
-    /// Reset your runtipi password
+    /// Initiate a password reset for the admin user
     ResetPassword,
     /// Debug your runtipi instance
     Debug,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,3 +3,4 @@ pub mod debug;
 pub mod start;
 pub mod stop;
 pub mod update;
+pub mod reset_password;

--- a/src/commands/reset_password.rs
+++ b/src/commands/reset_password.rs
@@ -1,10 +1,25 @@
-use std::{fs::File, path::PathBuf};
-use std::env;
 use colored::Colorize;
+use std::env;
+use std::{fs::File, path::PathBuf};
 
 pub fn run() {
     let root_folder: PathBuf = env::current_dir().expect("Unable to get current directory");
-    let mut _reset_password_request = File::create(root_folder.join("state").join("password-change-request"));
-    print!("{}", "✓ ".green());
-    println!("Password reset request created. Head back to the dashboard to set a new password.")
+    let reset_password_request = File::create(root_folder.join("state").join("password-change-request"));
+
+    match reset_password_request {
+        Ok(_) => {
+            println!(
+                "{} Password reset request created. Head back to the dashboard to set a new password.",
+                "✓".green()
+            )
+        }
+        Err(_) => {
+            println!(
+                "{} Unable to create password reset request. You can manually create an empty file at {} to initiate a password reset.",
+                "✗".red(),
+                root_folder.join("state").join("password-change-request").to_str().unwrap()
+            );
+            return;
+        }
+    }
 }

--- a/src/commands/reset_password.rs
+++ b/src/commands/reset_password.rs
@@ -1,0 +1,10 @@
+use std::{fs::File, path::PathBuf};
+use std::env;
+use colored::Colorize;
+
+pub fn run() {
+    let root_folder: PathBuf = env::current_dir().expect("Unable to get current directory");
+    let mut _reset_password_request = File::create(root_folder.join("state").join("password-change-request"));
+    print!("{}", "✓ ".green());
+    println!("Password reset request created. Head back to the dashboard to set a new password.")
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use crate::commands::update::UpdateArgs;
 fn main() {
     let args = RuntipiArgs::parse();
 
-    println!("{}", "Welcome to Runtipi CLI ✨".green());
+    println!("{}", "Welcome to Runtipi CLI ✨\n".green());
 
     match args.command {
         args::RuntipiMainCommand::Start(args) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use crate::commands::update::UpdateArgs;
 fn main() {
     let args = RuntipiArgs::parse();
 
-    println!("{}", "Welcome to Runtipi CLI ✨\n".green());
+    println!("{}", "Welcome to Runtipi CLI ✨".green());
 
     match args.command {
         args::RuntipiMainCommand::Start(args) => {
@@ -34,6 +34,9 @@ fn main() {
 
             commands::stop::run();
             commands::update::run(args);
+        }
+        args::RuntipiMainCommand::ResetPassword => {
+            commands::reset_password::run();
         }
         args::RuntipiMainCommand::App(app_command) => {
             commands::app::run(app_command);

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -2,7 +2,6 @@ use hex::encode;
 
 use sha2::{Digest, Sha256};
 use std::io::{Error, ErrorKind, Write};
-use std::os::unix::fs::MetadataExt;
 use std::{env, fs};
 use std::{fs::File, path::PathBuf};
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a `Reset Password` command to the CLI, allowing users to initiate a password reset process.

- **Bug Fixes**
	- Removed an unnecessary import that could cause compatibility issues on non-Unix systems.

- **Refactor**
	- Updated the CLI welcome message for improved user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->