### PR TITLE
Use hostname and port from `.env`

### DIFF
--- a/src/commands/app.rs
+++ b/src/commands/app.rs
@@ -1,15 +1,21 @@
 use std::io::Error;
 
 use crate::args::{AppCommand, AppSubcommand};
-use crate::utils::env::get_env_value;
+use crate::utils::env::{EnvMap, get_env_value};
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
 
 use crate::components::spinner;
 use reqwest::blocking::{Client, Response};
+use crate::utils::constants::DEFAULT_NGINX_PORT;
 
-pub fn run(args: AppCommand) {
-    let base_url = "http://localhost/worker-api/apps";
+pub fn run(args: AppCommand, env_map: EnvMap) {
+
+    let base_url = format!(
+        "http://{}:{}/worker-api/apps",
+        env_map.get("INTERNAL_IP").unwrap_or(&"localhost".to_string()),
+        env_map.get("NGINX_PORT").unwrap_or(&DEFAULT_NGINX_PORT.to_string()),
+    );
 
     match args.subcommand {
         AppSubcommand::Start(args) => {

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -3,9 +3,9 @@ use colored::Colorize;
 use prettytable::{format, row, Table};
 use serde_json::{to_string_pretty, Value};
 
-use crate::utils::{env::env_string_to_map, system::get_architecture};
+use crate::utils::{system::get_architecture, env::EnvMap};
 
-pub fn run() {
+pub fn run(env_map: EnvMap) {
     println!("⚠️ Make sure you have started tipi before running this command\n");
     // Gather system information
     let os = std::env::consts::OS;
@@ -57,10 +57,6 @@ pub fn run() {
     println!("\n--- {} ---", "Environment variables".blue());
     let mut table = Table::new();
     table.set_format(*format::consts::FORMAT_BOX_CHARS);
-
-    let env_file_path = current_dir.join(".env");
-    let env_file = std::fs::read_to_string(&env_file_path).unwrap_or_default();
-    let env_map = env_string_to_map(env_file.as_str());
 
     let pg_password = env_map
         .get("POSTGRES_PASSWORD")

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,17 @@ use clap::Parser;
 use colored::Colorize;
 
 use crate::commands::update::UpdateArgs;
+use crate::utils::env::env_string_to_map;
 
 fn main() {
     let args = RuntipiArgs::parse();
 
     println!("{}", "Welcome to Runtipi CLI ✨\n".green());
+
+    let current_dir = std::env::current_dir().unwrap_or_default();
+    let env_file_path = current_dir.join(".env");
+    let env_file = std::fs::read_to_string(&env_file_path).unwrap_or_default();
+    let env_map = env_string_to_map(env_file.as_str());
 
     match args.command {
         args::RuntipiMainCommand::Start(args) => {
@@ -39,10 +45,10 @@ fn main() {
             commands::reset_password::run();
         }
         args::RuntipiMainCommand::App(app_command) => {
-            commands::app::run(app_command);
+            commands::app::run(app_command, env_map);
         }
         args::RuntipiMainCommand::Debug => {
-            commands::debug::run();
+            commands::debug::run(env_map);
         }
     }
 }

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -12,7 +12,9 @@ use crate::utils::system::{derive_entropy, get_architecture, get_internal_ip, ge
 use super::constants::{DEFAULT_DOMAIN, DEFAULT_LOCAL_DOMAIN, DEFAULT_POSTGRES_PORT};
 use super::schemas::StringOrInt;
 
-pub fn get_env_map() -> HashMap<String, String> {
+pub type EnvMap = HashMap<String, String>;
+
+pub fn get_env_map() -> EnvMap {
     let root_folder: PathBuf = env::current_dir().expect("Unable to get current directory");
     let env_file_path = root_folder.join(".env");
 
@@ -25,7 +27,7 @@ pub fn get_env_value(key: &str) -> Option<String> {
     env_map.get(key).map(|value| value.to_string())
 }
 
-pub fn env_string_to_map(env_string: &str) -> std::collections::HashMap<String, String> {
+pub fn env_string_to_map(env_string: &str) -> EnvMap {
     let mut env_map = std::collections::HashMap::new();
 
     for line in env_string.lines() {
@@ -48,7 +50,7 @@ pub fn env_string_to_map(env_string: &str) -> std::collections::HashMap<String, 
     env_map
 }
 
-pub fn env_map_to_string(env_map: &HashMap<String, String>) -> String {
+pub fn env_map_to_string(env_map: &EnvMap) -> String {
     let mut env_string = String::new();
 
     for (key, value) in env_map {
@@ -88,7 +90,7 @@ pub fn generate_env_file(custom_env_file_path: Option<PathBuf>) -> Result<(), Er
     let version = std::fs::read_to_string(root_folder.join("VERSION"))?;
 
     // Create a new env map with the default values
-    let mut new_env_map: HashMap<String, String> = HashMap::new();
+    let mut new_env_map: EnvMap = HashMap::new();
 
     let seed = get_seed(&root_folder);
     let postgres_password: String = env_map


### PR DESCRIPTION
Read hostname and port from `.env` file when running action in `app` command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic construction of `base_url` using environment variables, enhancing flexibility in different environments.
	- Added the ability to read and parse environment variables from a file for streamlined configuration management.
- **Refactor**
	- Updated command functions to utilize an `EnvMap` parameter for environment variable management, improving code readability and maintainability.
- **Chores**
	- Enhanced utility functions for environment variable handling, including type aliasing and map initialization improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->