### PR TITLE
Update reset password command to add an expiration timestamp to the file created

### DIFF
--- a/src/commands/reset_password.rs
+++ b/src/commands/reset_password.rs
@@ -1,12 +1,13 @@
 use colored::Colorize;
 use std::env;
-use std::{fs::File, path::PathBuf};
+use std::{fs::write, path::PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::utils::env::get_env_value;
 
 pub fn run() {
     let root_folder: PathBuf = env::current_dir().expect("Unable to get current directory");
-    let reset_password_request = File::create(root_folder.join("state").join("password-change-request"));
+    let reset_password_request = write(root_folder.join("state").join("password-change-request"), (SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + (15 * 60)).to_string());
 
     match reset_password_request {
         Ok(_) => {
@@ -22,7 +23,7 @@ pub fn run() {
         }
         Err(e) => {
             println!(
-                "{} Unable to create password reset request. You can manually create an empty file at {} to initiate a password reset. Error: {}",
+                "{} Unable to create password reset request. You can manually create a file with `echo $(($(date +%s) + 900)) >> {}` to initiate a password reset. Error: {}",
                 "✗".red(),
                 root_folder
                     .join("state")

--- a/src/commands/reset_password.rs
+++ b/src/commands/reset_password.rs
@@ -7,7 +7,7 @@ use crate::utils::env::get_env_value;
 
 pub fn run() {
     let root_folder: PathBuf = env::current_dir().expect("Unable to get current directory");
-    let reset_password_request = write(root_folder.join("state").join("password-change-request"), (SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + (15 * 60)).to_string());
+    let reset_password_request = write(root_folder.join("state").join("password-change-request"), SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs().to_string());
 
     match reset_password_request {
         Ok(_) => {


### PR DESCRIPTION
This PR addresses https://github.com/runtipi/runtipi/issues/1065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Improved password reset functionality to ensure requests are processed correctly and securely.
  
- **Enhancements**
  - Password reset requests now have a more accurate timestamp, expiring 15 minutes from the request time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->