### PR TITLE
chore: add missing parenthesis to badge template

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -7,7 +7,7 @@
   "commitType": "docs",
   "commitConvention": "angular",
   "contributorsPerLine": 7,
-  "badgeTemplate": "[![All Contributors](https://img.shields.io/github/runtipi/cli](#contributors)",
+  "badgeTemplate": "[![All Contributors](https://img.shields.io/github/runtipi/cli)](#contributors)",
   "contributors": [
     {
       "login": "meienberger",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a broken URL in the All Contributors badge to ensure it displays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->