### PR TITLE
chore(docker-compose): remove labels associated with socket

### DIFF
--- a/src/assets/docker-compose.yml
+++ b/src/assets/docker-compose.yml
@@ -107,32 +107,6 @@ services:
       traefik.http.routers.dashboard-local.tls: true
       traefik.http.routers.dashboard-local.service: dashboard
 
-      # ---- socket ----- #
-      traefik.http.services.socket.loadbalancer.server.port: 5001
-      # Local ip
-      traefik.http.routers.socket.rule: PathPrefix("/api/socket.io")
-      traefik.http.routers.socket.service: socket
-      traefik.http.routers.socket.entrypoints: web
-      # Websecure
-      traefik.http.routers.socket-insecure.rule: Host(`${DOMAIN}`) && PathPrefix(`/api/socket.io`)
-      traefik.http.routers.socket-insecure.service: socket
-      traefik.http.routers.socket-insecure.entrypoints: web
-      traefik.http.routers.socket-insecure.middlewares: redirect-to-https
-      traefik.http.routers.socket-secure.rule: Host(`${DOMAIN}`) && PathPrefix(`/api/socket.io`)
-      traefik.http.routers.socket-secure.service: socket
-      traefik.http.routers.socket-secure.entrypoints: websecure
-      traefik.http.routers.socket-secure.tls.certresolver: myresolver
-      # Local domain
-      traefik.http.routers.socket-local-insecure.rule: Host(`${LOCAL_DOMAIN}`) && PathPrefix("/api/socket.io")
-      traefik.http.routers.socket-local-insecure.entrypoints: web
-      traefik.http.routers.socket-local-insecure.service: socket
-      traefik.http.routers.socket-local-insecure.middlewares: redirect-to-https
-      # Secure
-      traefik.http.routers.socket-local.rule: Host(`${LOCAL_DOMAIN}`) && PathPrefix("/api/socket.io")
-      traefik.http.routers.socket-local.entrypoints: websecure
-      traefik.http.routers.socket-local.tls: true
-      traefik.http.routers.socket-local.service: socket
-
 networks:
   tipi_main_network:
     driver: bridge


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
	- Removed Traefik router and service configurations related to socket service
	- Simplified routing configuration in docker-compose file
	- No impact on core service functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->