### PR TITLE
feat: add runtipi-queue

### DIFF
--- a/src/assets/docker-compose.yml
+++ b/src/assets/docker-compose.yml
@@ -36,6 +36,21 @@ services:
     networks:
       - tipi_main_network
 
+  runtipi-queue:
+    container_name: runtipi-queue
+    image: rabbitmq:4-alpine
+    restart: unless-stopped
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    environment:
+      RABBITMQ_DEFAULT_USER: tipi
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
+    networks:
+      - tipi_main_network
+
   runtipi:
     container_name: runtipi
     healthcheck:

--- a/src/assets/docker-compose.yml
+++ b/src/assets/docker-compose.yml
@@ -64,6 +64,8 @@ services:
     depends_on:
       runtipi-db:
         condition: service_healthy
+      runtipi-queue:
+        condition: service_healthy
     env_file:
       - .env
     volumes:

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -62,8 +62,8 @@ pub fn run(env_map: EnvMap) {
         .get("POSTGRES_PASSWORD")
         .map(|_| "<redacted>".to_string())
         .unwrap_or("Not set".red().to_string());
-    let redis_password = env_map
-        .get("REDIS_PASSWORD")
+    let rabbitmq_password = env_map
+        .get("RABBITMQ_PASSWORD")
         .map(|_| "<redacted>".to_string())
         .unwrap_or("Not set".red().to_string());
     let jwt_secret = env_map
@@ -73,7 +73,7 @@ pub fn run(env_map: EnvMap) {
     let domain = env_map.get("DOMAIN").map(|_| "<redacted>").unwrap_or("Not set");
 
     table.add_row(row!["POSTGRES_PASSWORD", pg_password]);
-    table.add_row(row!["REDIS_PASSWORD", redis_password]);
+    table.add_row(row!["RABBITMQ_PASSWORD", rabbitmq_password]);
     table.add_row(row!["APPS_REPO_ID", env_map.get("APPS_REPO_ID").unwrap_or(&"Not set".red().to_string())]);
     table.add_row(row![
         "APPS_REPO_URL",
@@ -107,7 +107,11 @@ pub fn run(env_map: EnvMap) {
         "POSTGRES_PORT",
         env_map.get("POSTGRES_PORT").unwrap_or(&"Not set".red().to_string())
     ]);
-    table.add_row(row!["REDIS_HOST", env_map.get("REDIS_HOST").unwrap_or(&"Not set".to_string())]);
+    table.add_row(row!["RABBITMQ_HOST", env_map.get("RABBITMQ_HOST").unwrap_or(&"Not set".to_string())]);
+    table.add_row(row![
+        "RABBITMQ_USERNAME",
+        env_map.get("RABBITMQ_USERNAME").unwrap_or(&"Not set".to_string())
+    ]);
     table.add_row(row!["DEMO_MODE", env_map.get("DEMO_MODE").unwrap_or(&"Not set".to_string())]);
     table.add_row(row!["LOCAL_DOMAIN", env_map.get("LOCAL_DOMAIN").unwrap_or(&"Not set".to_string())]);
 

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -98,9 +98,9 @@ pub fn generate_env_file(custom_env_file_path: Option<PathBuf>) -> Result<(), Er
         .get("POSTGRES_PASSWORD")
         .unwrap_or(&derive_entropy("postgres_password", &seed))
         .to_string();
-    let redis_password: String = env_map
-        .get("REDIS_PASSWORD")
-        .unwrap_or(&derive_entropy("redis_password", &seed))
+    let rabbitmq_password: String = env_map
+        .get("RABBITMQ_PASSWORD")
+        .unwrap_or(&derive_entropy("rabbitmq_password", &seed))
         .to_string();
 
     let app_data_path = parsed_json.app_data_path.or(parsed_json.storage_path.clone());
@@ -148,8 +148,9 @@ pub fn generate_env_file(custom_env_file_path: Option<PathBuf>) -> Result<(), Er
     new_env_map.insert("POSTGRES_DBNAME".to_string(), "tipi".to_string());
     new_env_map.insert("POSTGRES_USERNAME".to_string(), "tipi".to_string());
     new_env_map.insert("POSTGRES_PASSWORD".to_string(), postgres_password);
-    new_env_map.insert("REDIS_HOST".to_string(), "runtipi-redis".to_string());
-    new_env_map.insert("REDIS_PASSWORD".to_string(), redis_password);
+    new_env_map.insert("RABBITMQ_HOST".to_string(), "runtipi-queue".to_string());
+    new_env_map.insert("RABBITMQ_USERNAME".to_string(), "tipi".to_string());
+    new_env_map.insert("RABBITMQ_PASSWORD".to_string(), rabbitmq_password);
     new_env_map.insert("DOMAIN".to_string(), parsed_json.domain.unwrap_or(DEFAULT_DOMAIN.to_string()));
     new_env_map.insert(
         "LOCAL_DOMAIN".to_string(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a messaging queue service that improves service startup reliability by ensuring dependent services launch only after the queue is fully operational.
  
- **Refactor**
  - Updated configuration and debug display settings to reflect the transition from the previous messaging setup to the new queue service for clearer environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->