### PR TITLE
ci: build for macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,20 @@ jobs:
             bin_name: runtipi-cli
             artifact_name: runtipi-cli-linux-x86_64
 
+          - release_for: macos-intel
+            os: ubuntu-latest
+            goos: darwin
+            goarch: amd64
+            bin_name: runtipi-cli
+            artifact_name: runtipi-cli-macos-intel
+
+          - release_for: macos-apple-silicon
+            os: ubuntu-latest
+            goos: darwin
+            goarch: arm64
+            bin_name: runtipi-cli
+            artifact_name: runtipi-cli-macos-apple-silicon
+
     runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Echo distinct ID ${{ github.event.inputs.distinct_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,20 @@ jobs:
             bin_name: runtipi-cli
             artifact_name: runtipi-cli-linux-x86_64
 
+          - release_for: macos-x86_64
+            os: ubuntu-latest
+            goos: darwin
+            goarch: amd64
+            bin_name: runtipi-cli
+            artifact_name: runtipi-cli-macos-x86_64
+
+          - release_for: macos-apple-aarch64
+            os: ubuntu-latest
+            goos: darwin
+            goarch: arm64
+            bin_name: runtipi-cli
+            artifact_name: runtipi-cli-macos-aarch64
+
     runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Echo distinct ID ${{ github.event.inputs.distinct_id }}
@@ -59,6 +73,7 @@ jobs:
             ./cmd/runtipi/main.go
 
       - name: Compress with upx
+        if: matrix.platform.goos == 'linux'
         run: |
           sudo apt-get install -y upx
           upx --best --lzma ${{ matrix.platform.bin_name }}
@@ -82,10 +97,10 @@ jobs:
         uses: actions/download-artifact@v5
 
       - name: Move artifacts
-        run: for dir in runtipi-cli-linux-*; do mv "$dir/runtipi-cli" "${dir}.cli" && rm -rf "$dir" && mv "${dir}.cli" "$dir"; done
+        run: for dir in runtipi-cli-*; do mv "$dir/runtipi-cli" "${dir}.cli" && rm -rf "$dir" && mv "${dir}.cli" "$dir"; done
 
       - name: Compress artifacts
-        run: for file in runtipi-cli-linux-*; do tar -czvf "$file.tar.gz" "$file" && rm -rf "$file"; done
+        run: for file in runtipi-cli-*; do tar -czvf "$file.tar.gz" "$file" && rm -rf "$file"; done
 
       - name: Create release
         id: create_release

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,20 @@ jobs:
             goarch: amd64
             bin_name: runtipi-cli
             artifact_name: runtipi-cli-linux-x86_64
+            
+          - release_for: macos-intel
+            os: ubuntu-latest
+            goos: darwin
+            goarch: amd64
+            bin_name: runtipi-cli
+            artifact_name: runtipi-cli-macos-intel
+
+          - release_for: macos-apple-silicon
+            os: ubuntu-latest
+            goos: darwin
+            goarch: arm64
+            bin_name: runtipi-cli
+            artifact_name: runtipi-cli-macos-apple-silicon
 
     runs-on: ${{ matrix.platform.os }}
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,20 @@ jobs:
             goarch: amd64
             bin_name: runtipi-cli
             artifact_name: runtipi-cli-linux-x86_64
+            
+          - release_for: macos-x86_64
+            os: ubuntu-latest
+            goos: darwin
+            goarch: amd64
+            bin_name: runtipi-cli
+            artifact_name: runtipi-cli-macos-x86_64
+
+          - release_for: macos-apple-aarch64
+            os: ubuntu-latest
+            goos: darwin
+            goarch: arm64
+            bin_name: runtipi-cli
+            artifact_name: runtipi-cli-macos-apple-aarch64
 
     runs-on: ${{ matrix.platform.os }}
     steps:
@@ -55,6 +69,7 @@ jobs:
             ./cmd/runtipi/main.go
 
       - name: Compress with upx
+        if: matrix.platform.goos == 'linux'
         run: |
           sudo apt-get install -y upx
           upx --best --lzma ${{ matrix.platform.bin_name }}
@@ -78,10 +93,10 @@ jobs:
         uses: actions/download-artifact@v5
 
       - name: Move artifacts
-        run: for dir in runtipi-cli-linux-*; do mv "$dir/runtipi-cli" "${dir}.cli" && rm -rf "$dir" && mv "${dir}.cli" "$dir"; done
+        run: for dir in runtipi-cli-*; do mv "$dir/runtipi-cli" "${dir}.cli" && rm -rf "$dir" && mv "${dir}.cli" "$dir"; done
 
       - name: Compress artifacts
-        run: for file in runtipi-cli-linux-*; do tar -czvf "$file.tar.gz" "$file" && rm -rf "$file"; done
+        run: for file in runtipi-cli-*; do tar -czvf "$file.tar.gz" "$file" && rm -rf "$file"; done
 
       - uses: pyTooling/Actions/releaser@r0
         with:


### PR DESCRIPTION
Currently, artifacts are built (both in nightly and release) only for linux. As a macOS user I'd like to have a corresponding release artifacts as well, since it's a lot less work than building it locally each time.

With these changes the _Release CLI_ and _Nightly Release CLI_ workflows build and publish the CLI also as macOS executable. Both the old intel and the new Apple silicon architecture are available.

A documentation update is imo also still necessary, but first I'd like to agree on the code/config changes.