### PR TITLE
feat: local cross platform build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,31 +3,56 @@
 # Define the root folder path
 ROOT_FOLDER_HOST := ~/temp/runtipi
 
+# Set environment variables for golang target platform if these are passed via command line
+ifdef GOOS
+ifdef GOARCH
+	export GOOS
+	export GOARCH
+endif
+endif
+
+# Read golang target platform from the system
+TARGET_OS := $$(go env GOOS)
+TARGET_ARCH := $$(go env GOARCH)
+
 # Main target that creates the directory and runs the program
 .PHONY: run
-run:
+run: current_platform
 	@mkdir -p $(ROOT_FOLDER_HOST)
 	@ROOT_FOLDER_HOST=$(ROOT_FOLDER_HOST) go run -ldflags="-X main.version=nightly -X main.commit=$(git rev-parse HEAD) -X main.buildDate=$(date +%Y-%m-%dT%H:%M:%S%z)" cmd/runtipi/main.go $(ARGS)
 
 # Build the program
 .PHONY: build
-build:
-	@go build -o runtipi-cli cmd/runtipi/main.go
+build: current_platform
+	@go build -o runtipi-cli-$(TARGET_OS)-$(TARGET_ARCH) cmd/runtipi/main.go
 
 # Clean build artifacts
 .PHONY: clean
 clean:
-	@rm -f runtipi-cli
+	@rm -f runtipi-cli-*
+
+# List all available golang target platforms
+.PHONY: available_platforms
+available_platforms:
+	@go tool dist list
+
+# Print which golang target platform is currently set
+.PHONY: current_platform
+current_platform:
+	@echo "Current golang target platform: $(TARGET_OS)/$(TARGET_ARCH)"
 
 # Help command
 .PHONY: help
 help:
 	@echo "Available commands:"
-	@echo "  make run ARGS=\"command arguments\"  - Run the program with specified arguments"
-	@echo "  make build                          - Build the program"
-	@echo "  make clean                          - Clean build artifacts"
-	@echo "  make help                           - Show this help message"
+	@echo "  make run ARGS=\"command arguments\"    - Run the program with specified arguments"
+	@echo "  make build                             - Build the program"
+	@echo "  make clean								- Clean build artifacts"
+	@echo "  make available_platforms            	- List golang target platforms available for the build"
+	@echo "  make current_platform					- Print current golang target platform"
+	@echo "  make help								- Show this help message"
 	@echo ""
 	@echo "Example usage:"
-	@echo "  make run ARGS=\"start\"               - Run the program with 'start' command"
-	@echo "  make run ARGS=\"update nightly\"       - Run the program with 'update nightly' command"
+	@echo "  make run ARGS=\"start\"				- Run the program with 'start' command"
+	@echo "  make run ARGS=\"update nightly\"		- Run the program with 'update nightly' command"
+	@echo "  make build GOOS=darwin GOARCH=arm64"	- Build the program for golang target platform 'darwin/arm64' (macOS silicon)

--- a/Makefile
+++ b/Makefile
@@ -41,18 +41,22 @@ available_platforms:
 current_platform:
 	@echo "Current golang target platform: $(TARGET_OS)/$(TARGET_ARCH)"
 
+# String formats to use for output of help command
+header_line_format='--------------------------------------\n%s\n--------------------------------------\n'
+line_format='  %-40s - %s\n' # Fix padding of first column to 40 chars
+
 # Help command
 .PHONY: help
 help:
-	@echo "Available commands:"
-	@echo "  make run ARGS=\"command arguments\"    - Run the program with specified arguments"
-	@echo "  make build                             - Build the program"
-	@echo "  make clean								- Clean build artifacts"
-	@echo "  make available_platforms            	- List golang target platforms available for the build"
-	@echo "  make current_platform					- Print current golang target platform"
-	@echo "  make help								- Show this help message"
-	@echo ""
-	@echo "Example usage:"
-	@echo "  make run ARGS=\"start\"				- Run the program with 'start' command"
-	@echo "  make run ARGS=\"update nightly\"		- Run the program with 'update nightly' command"
-	@echo "  make build GOOS=darwin GOARCH=arm64"	- Build the program for golang target platform 'darwin/arm64' (macOS silicon)
+	@printf -- $(header_line_format) "Available commands"
+	@printf $(line_format) "make run ARGS=\"command arguments\"" 	"Run the program with specified arguments"
+	@printf $(line_format) "make build" 							"Build the program"
+	@printf $(line_format) "make clean"								"Clean build artifacts"
+	@printf $(line_format) "make available_platforms"				"List golang target platforms available for the build"
+	@printf $(line_format) "make current_platform"					"Print current golang target platform"
+	@printf $(line_format) "make help"								"Show this help message"
+	@printf "\n"
+	@printf -- $(header_line_format) "Example usage"
+	@printf $(line_format) "make run ARGS=\"start\""				"Run the program with 'start' command"
+	@printf $(line_format) "make run ARGS=\"update nightly\""		"Run the program with 'update nightly' command"
+	@printf $(line_format) "make build GOOS=darwin GOARCH=arm64"	"Build the program for golang target platform 'darwin/arm64' (macOS silicon)"


### PR DESCRIPTION
With these changes it is possible to locally cross compile the CLI by simply providing `GOOS` and `GOARCH` parameters to the make command. E.g. `make build GOOS=darwin GOARCH=arm64`. In this way it is possible to develop and test on different operating systems and architectures.

Additionally I added two more targets to the `Makefile`:
- `available_platforms` displays information about the available golang target platforms (os/archtiecture)
- `current_platform` shows the currently configured target platform

Lastly the `help` target was accordingly extended and refactored to provide consistent and flexible formatting.

The documentation should still be updated to reflect these changes, but any constructive feedback about the code changes is already very welcome.