### PR TITLE
feat: add prepare command

### DIFF
--- a/cmd/runtipi/main.go
+++ b/cmd/runtipi/main.go
@@ -71,6 +71,7 @@ func main() {
 
 	// Common flags
 	var startArgs types.StartArgs
+	var prepareArgs types.StartArgs
 	var restartArgs types.StartArgs
 	var updateArgs types.UpdateArgs
 	var appArgs types.AppArgs
@@ -86,6 +87,17 @@ func main() {
 	}
 	startCmd.Flags().StringVar(&startArgs.EnvFile, "env-file", "", "Path to a custom .env file. Can be relative to the current directory or absolute.")
 	startCmd.Flags().BoolVar(&startArgs.NoPermissions, "no-permissions", false, "Skip setting file permissions (not recommended)")
+
+	prepareCmd := &cobra.Command{
+		Use:   "prepare",
+		Short: "Prepare the environment without starting containers",
+		Long:  "Prepare the Runtipi environment by checking permissions, copying files, and generating configuration. This does not start any Docker containers.",
+		Run: func(cmd *cobra.Command, args []string) {
+			commands.RunPrepare(prepareArgs)
+		},
+	}
+	prepareCmd.Flags().StringVar(&prepareArgs.EnvFile, "env-file", "", "Path to a custom .env file. Can be relative to the current directory or absolute.")
+	prepareCmd.Flags().BoolVar(&prepareArgs.NoPermissions, "no-permissions", false, "Skip setting file permissions (not recommended)")
 
 	// Stop command
 	stopCmd := &cobra.Command{
@@ -344,6 +356,7 @@ func main() {
 
 	// Add commands to root command
 	rootCmd.AddCommand(startCmd)
+	rootCmd.AddCommand(prepareCmd)
 	rootCmd.AddCommand(stopCmd)
 	rootCmd.AddCommand(restartCmd)
 	rootCmd.AddCommand(updateCmd)

--- a/internal/commands/prepare.go
+++ b/internal/commands/prepare.go
@@ -1,0 +1,67 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/runtipi/cli/internal/components"
+	"github.com/runtipi/cli/internal/types"
+	"github.com/runtipi/cli/internal/utils"
+)
+
+func PrepareEnvironment(args types.StartArgs) error {
+	spin := components.NewSpinner("Checking user permissions")
+	if err := utils.EnsureDocker(); err != nil {
+		spin.Fail(err.Error())
+		spin.Finish()
+		return err
+	}
+	spin.Succeed("User permissions are ok")
+
+	spin.SetMessage("Copying system files...")
+	if err := utils.CopySystemFiles(); err != nil {
+		spin.Fail("Failed to copy system files")
+		spin.Finish()
+		return fmt.Errorf("failed to copy system files: %w", err)
+	}
+	spin.Succeed("Copied system files")
+
+	spin.SetMessage("Generating .env file...")
+	if err := utils.GenerateEnvFile(args.EnvFile); err != nil {
+		spin.Fail("Failed to generate .env file")
+		spin.Finish()
+		return fmt.Errorf("failed to generate .env file: %w", err)
+	}
+	spin.Succeed("Generated .env file")
+
+	if !args.NoPermissions {
+		spin.SetMessage("Ensuring file permissions... This may take a while depending on how many files there are to fix")
+		if err := utils.EnsureFilePermissions(); err != nil {
+			spin.Fail(err.Error())
+			spin.Finish()
+			return fmt.Errorf("failed to ensure file permissions: %w", err)
+		}
+	}
+	spin.Succeed("File permissions ok")
+	spin.Finish()
+
+	return nil
+}
+
+func RunPrepare(args types.StartArgs) {
+	if err := validateStartArgs(args); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	if err := PrepareEnvironment(args); err != nil {
+		fmt.Printf("\nError: %v\n", err)
+		return
+	}
+
+	fmt.Println()
+	boxTitle := "Environment prepared successfully"
+	boxBody := "The environment has been prepared.\n\nYou can now run 'start' to launch the containers."
+
+	consoleBox := components.NewConsoleBox(boxTitle, boxBody, 80, "Green")
+	consoleBox.Print()
+}

--- a/internal/commands/prepare.go
+++ b/internal/commands/prepare.go
@@ -40,8 +40,10 @@ func PrepareEnvironment(args types.StartArgs) error {
 			spin.Finish()
 			return fmt.Errorf("failed to ensure file permissions: %w", err)
 		}
+		spin.Succeed("File permissions ok")
+	} else {
+		spin.Warn("File permissions check skipped")
 	}
-	spin.Succeed("File permissions ok")
 	spin.Finish()
 
 	return nil

--- a/internal/commands/start.go
+++ b/internal/commands/start.go
@@ -12,53 +12,27 @@ import (
 	"github.com/runtipi/cli/internal/utils"
 )
 
-func RunStart(args types.StartArgs) {
-	// Validate args
+func validateStartArgs(args types.StartArgs) error {
 	if args.EnvFile != "" {
 		if _, err := os.Stat(args.EnvFile); os.IsNotExist(err) {
-			fmt.Printf("Error: file %s does not exist\n", args.EnvFile)
-			return
+			return fmt.Errorf("file %s does not exist", args.EnvFile)
 		}
 	}
+	return nil
+}
 
-	spin := components.NewSpinner("Checking user permissions")
-	if err := utils.EnsureDocker(); err != nil {
-		spin.Fail(err.Error())
-		spin.Finish()
+func RunStart(args types.StartArgs) {
+	if err := validateStartArgs(args); err != nil {
+		fmt.Printf("Error: %v\n", err)
 		return
 	}
-	spin.Succeed("User permissions are ok")
 
-	spin.SetMessage("Copying system files...")
-	if err := utils.CopySystemFiles(); err != nil {
-		spin.Fail("Failed to copy system files")
-		spin.Finish()
+	if err := PrepareEnvironment(args); err != nil {
 		fmt.Printf("\nError: %v\n", err)
 		return
 	}
-	spin.Succeed("Copied system files")
 
-	spin.SetMessage("Generating .env file...")
-	if err := utils.GenerateEnvFile(args.EnvFile); err != nil {
-		spin.Fail("Failed to generate .env file")
-		spin.Finish()
-		fmt.Printf("\nError: %v\n", err)
-		return
-	}
-	spin.Succeed("Generated .env file")
-
-	if !args.NoPermissions {
-		spin.SetMessage("Ensuring file permissions... This may take a while depending on how many files there are to fix")
-		if err := utils.EnsureFilePermissions(); err != nil {
-			spin.Fail(err.Error())
-			spin.Finish()
-			fmt.Printf("\nError: %v\n", err)
-			return
-		}
-	}
-	spin.Succeed("File permissions ok")
-
-	spin.SetMessage("Pulling images...")
+	spin := components.NewSpinner("Pulling images...")
 
 	envFilePath := filepath.Join(config.RootFolder, ".env")
 	cmd := exec.Command(


### PR DESCRIPTION
Adds a new `prepare` command to allow creating the necessary files without starting the containers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `prepare` command to initialize the application environment and generate configuration.
  * `prepare` supports `--env-file` and `--no-permissions` flags.

* **Improvements**
  * Start flow now reuses preparation steps and shows clearer progress (e.g., "Pulling images...") and a final message confirming the environment is ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->