### PR TITLE
chore: bump traefik version

### DIFF
--- a/internal/assets/docker-compose.yml
+++ b/internal/assets/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     depends_on:
       runtipi:
         condition: service_healthy
-    image: traefik:v3.6.6
+    image: traefik:v3.7
     restart: unless-stopped
     ports:
       - ${NGINX_PORT:-80}:80


### PR DESCRIPTION
Solves https://github.com/runtipi/runtipi-appstore/issues/10501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the reverse proxy service runtime to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->